### PR TITLE
update admin view so that a message that is not allowed will be remov…

### DIFF
--- a/src/components/AdminSqueak/AdminSqueak.js
+++ b/src/components/AdminSqueak/AdminSqueak.js
@@ -1,8 +1,27 @@
 import React from "react";
+import { useMutation } from "@apollo/client";
+import { GetReported } from "../../queries/getReported";
+import { DELETE_SQUEAK } from "../../queries/deleteSqueak";
+
 // import chippy from "../../images/SqueakerIcon.png";
 
 export const AdminSqueak = ({ id, content, metric, probability, user }) => {
   const { username } = user;
+  const { refetch } = GetReported();
+
+  const [removeSqueak] = useMutation(DELETE_SQUEAK, {
+    variables: {
+      id: id,
+    },
+    onCompleted: () => {
+      refetch();
+    },
+  });
+
+  const deleteReportedSqueak = () => {
+    removeSqueak();
+  };
+
   return (
     <div className="squeak">
         <p>{username}</p>
@@ -13,7 +32,7 @@ export const AdminSqueak = ({ id, content, metric, probability, user }) => {
         <h6> {metric}</h6>
         <h6>{probability}</h6>
         <button onClick="">👍</button>
-        <button onClick="">👎</button>
+        <button onClick={() => deleteReportedSqueak()}>👎</button>
       </div>
     </div>
   );

--- a/src/queries/getReported.js
+++ b/src/queries/getReported.js
@@ -22,11 +22,12 @@ const GET_REPORTED = gql`
 `;
 
 export const GetReported = () => {
-  const { data, error, loading } = useQuery(GET_REPORTED);
+  const { data, error, loading, refetch } = useQuery(GET_REPORTED);
 
   return {
     data,
     error,
     loading,
+    refetch
   };
 };


### PR DESCRIPTION
# Description

This commit passes delete squeak functionality to the admin when viewing a squeak that has been reported by another user.  We are now out of reported squeaks to view and need to talk to the backend about the report squeak mutation which still isnt available on their readme 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Browser
- [ ] Cypress End-to-End

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

