### PR TITLE
add new mutation to approve a reported message

### DIFF
--- a/src/Mutations/addReports.js
+++ b/src/Mutations/addReports.js
@@ -5,7 +5,7 @@ export const ADD_REPORT = gql`
     updateSqueak(input: { id: $id, report: $report}) {
       squeak {
         content
-        nuts
+        reports
       }
     }
   }

--- a/src/Mutations/approveSqueak.js
+++ b/src/Mutations/approveSqueak.js
@@ -1,0 +1,14 @@
+import { gql } from "@apollo/client";
+
+export const APPROVE_SQUEAK = gql`
+mutation approveSqueak ($id: ID!, $approved: Boolean!) {
+    updateSqueak(input: {id: $id, approved: $approved }) {
+      squeak {
+        id
+        content
+        approved
+        reports
+      }
+    }
+   }
+`;

--- a/src/components/AdminSqueak/AdminSqueak.js
+++ b/src/components/AdminSqueak/AdminSqueak.js
@@ -2,9 +2,9 @@ import React from "react";
 import { useMutation } from "@apollo/client";
 import { GetReported } from "../../queries/getReported";
 import { DELETE_SQUEAK } from "../../Mutations/deleteSqueak";
+import { APPROVE_SQUEAK } from "../../Mutations/approveSqueak";
 import '../App/App.css'
 import '../Squeak/Squeak.css'
-
 // import chippy from "../../images/SqueakerIcon.png";
 
 export const AdminSqueak = ({ id, content, metric, probability, user }) => {
@@ -12,18 +12,26 @@ export const AdminSqueak = ({ id, content, metric, probability, user }) => {
   const { refetch } = GetReported();
 
   const [removeSqueak] = useMutation(DELETE_SQUEAK, {
+    variables: { id: id },
+    onCompleted: () => {
+      refetch();
+    }
+  });
+
+  const deleteReportedSqueak = () => removeSqueak();
+
+  const [approveSqueak] = useMutation(APPROVE_SQUEAK, {
     variables: {
       id: id,
+      approved: true
     },
     onCompleted: () => {
       refetch();
-    },
+    }
   });
 
-  const deleteReportedSqueak = () => {
-    removeSqueak();
-  };
-
+  const approveClick = () => approveSqueak();
+ 
   return (
     <div className="squeak">
         <p>{username}</p>
@@ -36,7 +44,7 @@ export const AdminSqueak = ({ id, content, metric, probability, user }) => {
         <span>{probability}</span>
       </div>
       <div className="squeak-options row">
-        <button className="admin-squeak-approve" onClick="">
+        <button className="admin-squeak-approve" onClick={() => approveSqueak()}>
           👍
           <span className="admin-squeak-approve-tooltip tooltip">
             Approve this Squeak
@@ -47,7 +55,6 @@ export const AdminSqueak = ({ id, content, metric, probability, user }) => {
           <span className="admin-squeak-deny-tooltip tooltip">
             Deny this Squeak
           </span>
-
         </button>
       </div>
     </div>

--- a/src/components/AdminSqueak/AdminSqueak.js
+++ b/src/components/AdminSqueak/AdminSqueak.js
@@ -29,8 +29,6 @@ export const AdminSqueak = ({ id, content, metric, probability, user }) => {
       refetch();
     }
   });
-
-  const approveClick = () => approveSqueak();
  
   return (
     <div className="squeak">

--- a/src/components/Squeak/Squeak.js
+++ b/src/components/Squeak/Squeak.js
@@ -8,7 +8,6 @@ import "./Squeak.css";
 import "../App/App.css"
 import chippy from '../../images/SqueakerIcon.png'
 
-
 export const Squeak = ({ squeak, userById }) => {
   const { content, user } = squeak;
   const { refetch } = GetSqueaks();
@@ -18,12 +17,17 @@ export const Squeak = ({ squeak, userById }) => {
       id: squeak.id,
       nut: true,
     },
-    optimisticResponse: {
-      ADD_NUT: {
-        id: squeak.id,
-        nut: true,
-      }
-    },
+    // optimisticResponse: {
+    //   updateSqueak: {
+    //     squeak: {
+    //       id: squeak.id,
+    //       content: squeak.content,
+    //       nuts:squeak.nuts + 1,
+    //       __typename: "Squeak"
+    //     },
+    //     __typename: "UpdateSqueakPayload"
+    //   },
+    // },
     onCompleted: () => {
       refetch();
     },
@@ -32,26 +36,31 @@ export const Squeak = ({ squeak, userById }) => {
   const [updateReport] = useMutation(ADD_REPORT, {
     variables: {
       id: squeak.id,
-      report: true,
+      report: true
     },
-    optimisticResponse: {
-      ADD_REPORT: {
-        id: squeak.id,
-        report: true,
-      }
-    },
+    // optimisticResponse: {
+    //   updateSqueak: {
+    //     squeak: {
+    //       id: squeak.id,
+    //       content: squeak.content,
+    //       reports: squeak.reports + 1,
+    //       __typename: "Squeak"
+    //     },
+    //     __typename: "UpdateSqueakPayload"
+    //   }
+    // },
     onCompleted: () => {
       refetch();
-    },
+    }
   });
 
   const [deleteSqueak] = useMutation(DELETE_SQUEAK, {
     variables: {
-      id: squeak.id,
+      id: squeak.id
     },
     onCompleted: () => {
       refetch();
-    },
+    }
   });
 
   const deleteClick = () => {
@@ -67,7 +76,6 @@ export const Squeak = ({ squeak, userById }) => {
         <span className="squeak-username">{user.username}</span>
       </div>
       <p className="row center squeak-text">{content}</p>
-
       <div className="squeak-options row">
         <button 
           className="squeak-nut-button" 
@@ -91,7 +99,6 @@ export const Squeak = ({ squeak, userById }) => {
             Report this Squeak
           </span>
         </button>
-
         {userById.id === squeak.user.id && 
           <button 
           className="squeak-delete-button" 


### PR DESCRIPTION
# Description

This PR adds a new mutation for the admin view of flagged squeaks.  Upon clicking the button the message should disappear in the DOM.  The approved message will still be available back in the admins "user view"

ADMIN LOGIN = admin_user

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Browser

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

