### PR TITLE
conditionally render the report button so a user cannot report their …

### DIFF
--- a/src/Mutations/hideSqueak.js
+++ b/src/Mutations/hideSqueak.js
@@ -1,0 +1,14 @@
+import { gql } from "@apollo/client";
+
+export const HIDE_SQUEAK = gql`
+mutation hideSqueak ($id: ID!, $approved: Boolean!){
+    updateSqueak(input: { id: $id, approved: $approved }) {
+      squeak {
+        id
+        content
+        approved
+        reports
+      }
+    }
+  }
+  `

--- a/src/components/Squeak/Squeak.js
+++ b/src/components/Squeak/Squeak.js
@@ -88,7 +88,7 @@ export const Squeak = ({ squeak, userById }) => {
           Give this Squeak a Nut
           </span>
         </button>
-        <button 
+        {userById.id !== squeak.user.id && <button 
           className="squeak-report-button"
           onClick={() => updateReport()}
           disabled={userById.isAdmin}
@@ -98,7 +98,7 @@ export const Squeak = ({ squeak, userById }) => {
           <span className="squeak-report-button-tooltip tooltip">
             Report this Squeak
           </span>
-        </button>
+        </button>}
         {userById.id === squeak.user.id && 
           <button 
           className="squeak-delete-button" 


### PR DESCRIPTION
# Description

Conditionally render the report button so a user can no longer see the report button on a squeak that they made themselves.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Browser

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

